### PR TITLE
Use puppet 5.0.1

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -1,10 +1,13 @@
 FROM asuforce/puppetserver
 
+RUN apt-get update \
+  && apt-get install -yqq git
+
 WORKDIR /etc/puppetlabs/code/environments
 RUN cp -r production development
 ADD . development
 
 WORKDIR /etc/puppetlabs/code/environments/development
 RUN cd manifests && rm hello.pp nginx.pp
-RUN bundle install
-RUN librarian-puppet install
+RUN bundle install --path vendor/bundle
+RUN bundle exec librarian-puppet install

--- a/Dockerfile-module
+++ b/Dockerfile-module
@@ -1,10 +1,11 @@
 FROM asuforce/puppet
 
-RUN apt-get update
+RUN apt-get update \
+  && apt-get install -yqq git
 
 RUN mkdir /etc/puppet
 ADD . /etc/puppet
 
 WORKDIR /etc/puppet
-RUN bundle install
-RUN librarian-puppet install --path vendor/modules
+RUN bundle install --path vendor/bundle
+RUN bundle exec librarian-puppet install --path vendor/modules

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'puppet',           '5.0.0'
+gem 'puppet',           '5.0.1'
 gem 'librarian-puppet', '2.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    facter (2.4.6)
+    facter (2.5.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
@@ -24,7 +24,7 @@ GEM
     locale (2.1.2)
     minitar (0.6.1)
     multipart-post (2.0.0)
-    puppet (5.0.0)
+    puppet (5.0.1)
       facter (> 2.0, < 4)
       gettext-setup (>= 0.10, < 1)
       hiera (>= 3.2.1, < 4)
@@ -46,7 +46,7 @@ PLATFORMS
 
 DEPENDENCIES
   librarian-puppet (= 2.2.3)
-  puppet (= 5.0.0)
+  puppet (= 5.0.1)
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 This is puppet 5 on docker playground
 
-Ubuntu 16:04 with puppet-agent 5.0.0
+Ubuntu 16:04 with puppet-agent 5.0.1
 
 ## first
 
-```
+```console
 $ git clone git@github.com:Asuforce/docker-puppet-playground.git
 $ cd /path/to/docker-puppet-playground
 ```
 
 ## Use Standalone mode
 
-```shell
+```console
 $ docker build -t puppet:standalone -f Dockerfile-standalone .
 $ docker run -itd --name standalone puppet:standalone
 $ docker exec standalone puppet apply /etc/puppet/manifests/hello.pp
@@ -23,7 +23,7 @@ You can see `hello, puppet!`
 
 ## Use Standalone mode with librarian-puppet
 
-```shell
+```console
 $ docker-compose -f module.yml up -d --build
 $ docker exec -it module puppet apply /etc/puppet/manifests/nginx.pp --modulepath vendor/modules
 ```
@@ -32,10 +32,9 @@ Access `http://localhost:8080/`
 
 You can see `Hello from Docker Container`
 
-
 ## Use Puppetserver
 
-```shell
+```console
 $ docker-compose up -d --build
 $ docker exec --privileged pmaster systemctl start puppetserver
 $ docker exec web001 puppet agent --test --server pmaster.local --environment development


### PR DESCRIPTION
ref: https://docs.puppet.com/puppet/latest/release_notes.html#puppet-501

puppet5 の[バグ](https://github.com/Asuforce/docker-puppet-playground/pull/1#issuecomment-314638159)が修正されたので、対応した